### PR TITLE
fix: change dependency links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript { //properties that you need to build the project
         mavenLocal()
         mavenCentral()
         jcenter()
-        maven { url 'https://software.r3.com/artifactory/corda-releases' }
+        maven { url 'https://download.corda.net/maven/corda-releases' }
     }
 
     dependencies {
@@ -44,7 +44,7 @@ allprojects { //Properties that you need to compile your project (The applicatio
         mavenLocal()
         jcenter()
         mavenCentral()
-        maven { url 'https://software.r3.com/artifactory/corda' }
+        maven { url 'https://download.corda.net/maven/corda-dependencies' }
         maven { url 'https://jitpack.io' }
     }
 

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -3,6 +3,6 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url 'https://jitpack.io' }
-    maven { url 'https://software.r3.com/artifactory/corda' }
+    maven { url 'https://download.corda.net/maven/corda-dependencies' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }


### PR DESCRIPTION
Errors found after try to build:

> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve net.corda.plugins:cordapp:5.0.12.
     Required by:
         project :
      > Could not resolve net.corda.plugins:cordapp:5.0.12.
         > Could not get resource 'https://software.r3.com/artifactory/corda-releases/net/corda/plugins/cordapp/5.0.12/cordapp-5.0.12.pom'.
            > Could not GET 'https://software.r3.com/artifactory/corda-releases/net/corda/plugins/cordapp/5.0.12/cordapp-5.0.12.pom'. Received status code 401 from server: 
   > Could not resolve net.corda.plugins:cordformation:5.0.12.
     Required by:
         project :
      > Could not resolve net.corda.plugins:cordformation:5.0.12.
         > Could not get resource 'https://software.r3.com/artifactory/corda-releases/net/corda/plugins/cordformation/5.0.12/cordformation-5.0.12.pom'.
            > Could not GET 'https://software.r3.com/artifactory/corda-releases/net/corda/plugins/cordformation/5.0.12/cordformation-5.0.12.pom'. Received status code 401 from server: 
   > Could not resolve net.corda.plugins:quasar-utils:5.0.12.
     Required by:
         project :
      > Could not resolve net.corda.plugins:quasar-utils:5.0.12.
         > Could not get resource 'https://software.r3.com/artifactory/corda-releases/net/corda/plugins/quasar-utils/5.0.12/quasar-utils-5.0.12.pom'.
            > Could not GET 'https://software.r3.com/artifactory/corda-releases/net/corda/plugins/quasar-utils/5.0.12/quasar-utils-5.0.12.pom'. Received status code 401 from server: 

This PR fix these errors above by putting updated dependency links.
